### PR TITLE
Fixed issue where many imports were not imported as type

### DIFF
--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "change-case": "^4.1.2",
-    "node-fetch": "^3.3.1",
     "pluralize": "^8.0.0"
   }
 }

--- a/lib/core/src/interfaces/IDatastoreProvider.ts
+++ b/lib/core/src/interfaces/IDatastoreProvider.ts
@@ -1,5 +1,4 @@
-import fetch from 'node-fetch'
-type FetchFunc = typeof fetch;
+type FetchFunc = typeof globalThis.fetch;
 import { type BaseModelClass } from '../typescript'
 
 export interface IDatastoreProvider<TModel> {

--- a/lib/data/package.json
+++ b/lib/data/package.json
@@ -20,17 +20,12 @@
     "vitest": "^0.32.2"
   },
   "dependencies": {
-    "@mikro-orm/core": "^5.7.12",
-    "@mikro-orm/postgresql": "^5.7.12",
+    "@mikro-orm/core": "^5.7.14",
+    "@mikro-orm/postgresql": "^5.7.14",
     "pg-format": "^1.0.4",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "@declaro/core": "^1.0.0-alpha.0",
-    "@mikro-orm/cli": "^5.7.12",
-    "@mikro-orm/core": "^5.7.12",
-    "@mikro-orm/migrations": "^5.7.12",
-    "@mikro-orm/postgresql": "^5.7.12",
-    "@mikro-orm/seeder": "^5.7.12"
+    "@declaro/core": "^1.0.0-alpha.0"
   }
 }

--- a/lib/data/src/databaseConnection.ts
+++ b/lib/data/src/databaseConnection.ts
@@ -1,6 +1,6 @@
-import { type IDatastoreProvider, BaseModel, type BaseModelClass } from '@declaro/core'
-import { EntityManager } from '@mikro-orm/core'
-import { EntityRepository } from '@mikro-orm/postgresql'
+import type { IDatastoreProvider, BaseModel, BaseModelClass } from '@declaro/core'
+import type { EntityManager } from '@mikro-orm/core'
+import type { EntityRepository } from '@mikro-orm/postgresql'
 
 
 export class DatabaseConnection<T extends BaseModel<any>> implements IDatastoreProvider<T> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,7 +283,7 @@
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
   integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
 
-"@mikro-orm/core@^5.7.12":
+"@mikro-orm/core@^5.7.14":
   version "5.7.14"
   resolved "https://registry.yarnpkg.com/@mikro-orm/core/-/core-5.7.14.tgz#25298e90a303ca79ba1295b5c63e917128bc87d1"
   integrity sha512-og2TJ4mRdGKF8ok/xSdGNbznm+WFF6VJosJnneulmY4VirRNfDfp7uNPBOinewigS4Q8Ntdirmponx4KrOoMBg==
@@ -305,7 +305,7 @@
     knex "2.5.1"
     sqlstring "2.3.3"
 
-"@mikro-orm/postgresql@^5.7.12":
+"@mikro-orm/postgresql@^5.7.14":
   version "5.7.14"
   resolved "https://registry.yarnpkg.com/@mikro-orm/postgresql/-/postgresql-5.7.14.tgz#630a8fbd3a1abc73625408cdd9593104cc6f662f"
   integrity sha512-3nF/UtUZ9a8jj0bD7ONeLRLg5MIHNKJngl7yR3c8sRz9yTAX6bT0lttbCxCeL4Q6/5XdcDtjgAQMUrYx1QVPhQ==
@@ -1620,11 +1620,6 @@ dargs@^7.0.0:
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
 
-data-uri-to-buffer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
-  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
-
 dateformat@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
@@ -1972,14 +1967,6 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-fetch-blob@^3.1.2, fetch-blob@^3.1.4:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
-  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
-  dependencies:
-    node-domexception "^1.0.0"
-    web-streams-polyfill "^3.0.3"
-
 figures@3.2.0, figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -2042,13 +2029,6 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
-
-formdata-polyfill@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
-  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
-  dependencies:
-    fetch-blob "^3.1.2"
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -3460,11 +3440,6 @@ node-addon-api@^3.2.1:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
-node-domexception@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
-  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
-
 node-fetch@2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
@@ -3478,15 +3453,6 @@ node-fetch@^2.6.7:
   integrity sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==
   dependencies:
     whatwg-url "^5.0.0"
-
-node-fetch@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
-  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
-  dependencies:
-    data-uri-to-buffer "^4.0.0"
-    fetch-blob "^3.1.4"
-    formdata-polyfill "^4.0.10"
 
 node-gyp-build@^4.3.0:
   version "4.6.0"
@@ -5327,11 +5293,6 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
-
-web-streams-polyfill@^3.0.3:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
-  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
- This caused issues when the built artifacts were used downstream such as on a client-side project
- Because Mikro was being loaded with its dynamic import support it broke all sorts of stuff
- Additionally, since fetch support is client-side only we can just rely on the browser's implementation and not node-fetch