### PR TITLE
Fixed bug where datastoreAbstract::upsert wouldn't handle / throw exceptions

### DIFF
--- a/lib/data/src/datastoreAbstract.ts
+++ b/lib/data/src/datastoreAbstract.ts
@@ -70,12 +70,7 @@ export abstract class AbstractStore<T extends BaseModel<any>> {
             this.insertIntoStore(obj);
         }
 
-        const updated: T = await new Promise((resolve, reject) => {
-            this.connection.upsert(obj).then((updated) => {
-                resolve(updated);
-            });
-        });
-
+        const updated: T = await this.connection.upsert(obj);
         this.insertIntoStore(updated);
 
         return updated;


### PR DESCRIPTION
- It was a promise wrapped by a promise that didn't catch the inner exception
- In addition, the double promise was unnecessary