### PR TITLE
Added toJSON method to BaseModel to assist with frontend entity usage

### DIFF
--- a/lib/core/src/typescript/baseModel.ts
+++ b/lib/core/src/typescript/baseModel.ts
@@ -1,7 +1,23 @@
+import type { JSONified } from "@declaro/data";
+
 export abstract class BaseModel<TId> {
     public constructor() {}
 
     abstract id: TId;
+
+    toJSON<T extends BaseModel<TId>>(): JSONified<T> {
+        let output: any = {};
+        for (let key in this) {
+            if (this.hasOwnProperty(key)) {
+                if (this[key] instanceof BaseModel) {
+                    output[key] = (this[key] as BaseModel<any>).id;
+                } else {
+                    output[key] = this[key];
+                }
+            }
+        }
+        return output;
+    }
 }
 
 export type BaseModelClass<T> = new (values?: Partial<T>) => T;


### PR DESCRIPTION
- Because the FE receives values from Mikro's toJSON they're essentially DTOs, not the shape of the actual entity
- We already have a type on the FE (JSONified) but we still need runtime code to actually be able to create the DTO of an entity
- This is mostly only used for creating new entities (`new Client().toJSON`) as the datastore layer expects the DTO shape, not the entity shape