### PR TITLE
Fix core dependency issues with @declaro/zod

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "apps/framework": {
       "name": "@declaro-apps/framework",
-      "version": "2.0.0-beta.129",
+      "version": "2.0.0-beta.132",
       "dependencies": {
         "@declaro/di": "^2.0.0-beta.40",
         "@nuxt/icon": "^1.5.0",
@@ -47,15 +47,15 @@
     },
     "lib/auth": {
       "name": "@declaro/auth",
-      "version": "2.0.0-beta.129",
+      "version": "2.0.0-beta.132",
       "dependencies": {
         "uuid": "^11.1.0",
         "zod": "^4.1.11",
       },
       "devDependencies": {
-        "@declaro/core": "^2.0.0-beta.129",
+        "@declaro/core": "^2.0.0-beta.132",
         "@declaro/redis": "workspace:^",
-        "@declaro/zod": "^2.0.0-beta.129",
+        "@declaro/zod": "^2.0.0-beta.132",
         "@types/bun": "^1.2.12",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/luxon": "^3.7.1",
@@ -78,7 +78,7 @@
     },
     "lib/core": {
       "name": "@declaro/core",
-      "version": "2.0.0-beta.129",
+      "version": "2.0.0-beta.132",
       "devDependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@types/bun": "^1.2.12",
@@ -102,11 +102,11 @@
     },
     "lib/data": {
       "name": "@declaro/data",
-      "version": "2.0.0-beta.129",
+      "version": "2.0.0-beta.132",
       "devDependencies": {
-        "@declaro/auth": "^2.0.0-beta.129",
-        "@declaro/core": "^2.0.0-beta.129",
-        "@declaro/zod": "^2.0.0-beta.129",
+        "@declaro/auth": "^2.0.0-beta.132",
+        "@declaro/core": "^2.0.0-beta.132",
+        "@declaro/zod": "^2.0.0-beta.132",
         "crypto-browserify": "^3.12.1",
         "typescript": "^5.8.3",
         "uuid": "^11.1.0",
@@ -120,9 +120,9 @@
     },
     "lib/redis": {
       "name": "@declaro/redis",
-      "version": "2.0.0-beta.129",
+      "version": "2.0.0-beta.132",
       "devDependencies": {
-        "@declaro/core": "^2.0.0-beta.129",
+        "@declaro/core": "^2.0.0-beta.132",
         "@types/ioredis-mock": "^8.2.5",
         "@vitest/coverage-v8": "^0.32.2",
         "ioredis": "^5.5.0",
@@ -140,15 +140,14 @@
     },
     "lib/zod": {
       "name": "@declaro/zod",
-      "version": "2.0.0-beta.129",
+      "version": "2.0.0-beta.132",
       "devDependencies": {
-        "@declaro/core": "^2.0.0-beta.129",
+        "@declaro/core": "^2.0.0-beta.132",
         "@types/bun": "^1.2.12",
         "typescript": "^5.5.4",
         "zod": "^4.1.11",
       },
       "peerDependencies": {
-        "@declaro/core": "^2.0.0-beta.50",
         "zod": "^4.1.11",
       },
     },

--- a/lib/core/tsconfig.json
+++ b/lib/core/tsconfig.json
@@ -6,6 +6,7 @@
         "declaration": true,
         "declarationMap": true,
         "sourceMap": true,
+        "rootDir": "src",
         "baseUrl": ".",
         "paths": {
             "#scope": ["./src/scope/index.ts"]

--- a/lib/zod/package.json
+++ b/lib/zod/package.json
@@ -35,7 +35,6 @@
         "zod": "^4.1.11"
     },
     "peerDependencies": {
-        "@declaro/core": "^2.0.0-beta.50",
         "zod": "^4.1.11"
     },
     "exports": {


### PR DESCRIPTION
Some instances load @declaro/zod before @declaro/core even though they are peerDependencies.

This attempts to get around such bun bugs.