### PR TITLE
Add Bun runtime support to package exports

### DIFF
--- a/lib/auth/package.json
+++ b/lib/auth/package.json
@@ -56,6 +56,7 @@
         "LICENSE.md"
     ],
     "exports": {
+        "bun": "./src/index.ts",
         "browser": {
             "types": "./dist/ts-browser/index.browser.d.ts",
             "import": "./dist/browser/index.browser.js"

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -55,6 +55,7 @@
         "src/**/*"
     ],
     "exports": {
+        "bun": "./src/index.ts",
         "import": {
             "browser": "./dist/browser/index.js",
             "types": "./dist/ts/index.d.ts",
@@ -66,6 +67,7 @@
     },
     "imports": {
         "#scope": {
+            "bun": "./src/scope/index.ts",
             "types": "./dist/ts/scope/index.d.ts",
             "import": "./dist/node/scope/index.js",
             "require": "./dist/node/scope/index.cjs",

--- a/lib/data/package.json
+++ b/lib/data/package.json
@@ -37,6 +37,7 @@
         "src/**/*"
     ],
     "exports": {
+        "bun": "./src/index.ts",
         "types": "./dist/ts/index.d.ts",
         "import": "./dist/node/index.js",
         "require": "./dist/node/index.cjs",

--- a/lib/redis/package.json
+++ b/lib/redis/package.json
@@ -52,6 +52,7 @@
         "readme.md"
     ],
     "exports": {
+        "bun": "./src/index.ts",
         "types": "./dist/ts/index.d.ts",
         "import": "./dist/node/index.js",
         "require": "./dist/node/index.cjs",

--- a/lib/zod/package.json
+++ b/lib/zod/package.json
@@ -39,6 +39,7 @@
         "zod": "^4.1.11"
     },
     "exports": {
+        "bun": "./src/index.ts",
         "types": "./dist/ts/index.d.ts",
         "import": "./dist/node/index.js",
         "require": "./dist/node/index.cjs",


### PR DESCRIPTION
## Summary
This PR adds native Bun runtime support across all library packages by configuring the `"bun"` export condition in their `package.json` files.

## Changes
- Added `"bun": "./src/index.ts"` export condition to the main exports in:
  - `lib/core/package.json`
  - `lib/auth/package.json`
  - `lib/data/package.json`
  - `lib/redis/package.json`
  - `lib/zod/package.json`
- Added `"bun": "./src/scope/index.ts"` export condition to the `#scope` import alias in `lib/core/package.json`

## Details
The Bun export condition is positioned as the first condition in the exports object, allowing the Bun runtime to directly consume TypeScript source files without requiring pre-compiled distributions. This enables faster development workflows and better compatibility with Bun's native TypeScript support.

https://claude.ai/code/session_01FPHJcndD47uU2JFojfxoMa